### PR TITLE
internal/evm: update LatestFork

### DIFF
--- a/internal/evm/forkdefs.go
+++ b/internal/evm/forkdefs.go
@@ -1,6 +1,6 @@
 package evm
 
-var LatestFork = "cancun"
+var LatestFork = "prague"
 
 var forkReg = map[string]*InstructionSetDef{
 	"frontier": {


### PR DESCRIPTION
Currently the most up-to-date fork is `prague`.